### PR TITLE
[FIX] account_document: Fix error on search for movements in reconcil…

### DIFF
--- a/account_document/models/account_move_line.py
+++ b/account_document/models/account_move_line.py
@@ -52,12 +52,11 @@ class AccountMoveLine(models.Model):
         return res
 
     @api.model
-    def domain_move_lines_for_reconciliation(self, excluded_ids=None,
-                                             str=False):
+    def domain_move_lines_for_reconciliation(self, str=False):
         """ Add move display name in search of move lines"""
         _super = super(AccountMoveLine, self)
         _get_domain = _super.domain_move_lines_for_reconciliation
-        domain = _get_domain(excluded_ids=excluded_ids, str=str)
+        domain = _get_domain(str=str)
         if not str and str != '/':
             return domain
         domain_trans_ref = [('move_id.display_name', 'ilike', str)]


### PR DESCRIPTION
…iation wizard

FIX #6

The argument 'excluded_ids' doesn't exist on original domain_move_lines_for_reconciliation() method.
Maybe there was a confusion with _domain_move_lines_for_manual_reconciliation which it does has that argument